### PR TITLE
Upgraded the `fortune` cog to work with slash commands

### DIFF
--- a/code/common/command_management/invoked_command_handler.py
+++ b/code/common/command_management/invoked_command_handler.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Callable
 
@@ -39,25 +40,42 @@ class InvokedCommandHandler(Module):
 
     def get_command_string_from_interaction(self, interaction: Interaction) -> str:
         command_name = interaction.command.name ## todo: Is this the name invoked by the user, or the actual name of the method?
-        options = " ".join([option.get("value") for option in interaction.data.get("options", [{}]) if option["value"] is not None])  ## todo: any other flavors of argument?
+
+        options = " ".join([option.get("value") for option in interaction.data.get("options", [{}]) if option.get("value") is not None])  ## todo: any other flavors of argument?
+        if (options != ""):
+            options = f" {options}" ## Prepend a spacer if necessary so everything has some room to breathe (see return below)
 
         ## These should always be slash commands, so the explicit '/' character is fine
-        return f"/{command_name} {options}"
+        return f"/{command_name}{options}"
 
 
-    async def handle_deferred_command(self, interaction: Interaction, action: Callable[..., InvokedCommand]):
+    async def handle_deferred_command(
+            self,
+            interaction: Interaction,
+            action: Callable[..., InvokedCommand],
+            ephemeral: bool = True,
+            callback: Callable[[InvokedCommand], None] = None
+    ):
         '''Handles user feedback when running a deferred command'''
 
         ## Acknowledge the command, and start the thinking state
         command_string = self.get_command_string_from_interaction(interaction)
-        await interaction.response.defer(ephemeral=True, thinking=True)
+        await interaction.response.defer(ephemeral=ephemeral, thinking=True)
 
         ## Act upon the command, giving human readable feedback if any errors pop up
         try:
             invoked_command = await action()
 
+            ## Let the client handle followup feedback if desired
+            if(callback is not None):
+                if(asyncio.iscoroutinefunction(callback)):
+                    await callback(invoked_command)
+                else:
+                    callback(invoked_command)
+                return
+
+            ## Otherwise provide some basic feedback, and (implicitly) clear the thinking state
             if (invoked_command.successful):
-                ## Ideally everything worked great!
                 await interaction.followup.send(f"<@{interaction.user.id}> used **{command_string}**")
             elif (invoked_command.human_readable_error_message is not None):
                 await interaction.followup.send(invoked_command.human_readable_error_message)
@@ -68,4 +86,8 @@ class InvokedCommandHandler(Module):
 
         except Exception as e:
             LOGGER.error("Unspecified error during command handling", e)
-            await interaction.followup.send(f"I'm sorry <@{interaction.user.id}>, I'm afraid I can't do that.\nSomething went wrong, and I couldn't complete the **{command_string}** command.", ephemeral=True)
+            await interaction.followup.send(
+                f"I'm sorry <@{interaction.user.id}>, I'm afraid I can't do that.\n" +
+                f"Something went wrong, and I couldn't complete the **{command_string}** command.",
+                ephemeral=True
+            )


### PR DESCRIPTION
- Added optional callback support to Invoked_command_handler, which will be called instead of the generic followup.response used previously
- Added support for explicitly setting the `ephemeral` state in an interaction's response in the invoked_command_handler