### PR TITLE
Fixed `admin reload_modules` to actually reload all modules (whoa!)

### DIFF
--- a/code/common/audio_player.py
+++ b/code/common/audio_player.py
@@ -296,7 +296,7 @@ class AudioPlayer(Cog):
 
 
     def __init__(self, bot: commands.Bot, channel_timeout_handler = None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(bot, *args, **kwargs)
 
         self.bot = bot
         self.admin_cog = kwargs.get('dependencies', {}).get('Admin')
@@ -312,7 +312,14 @@ class AudioPlayer(Cog):
         self.ffmpeg_parameters = CONFIG_OPTIONS.get(self.FFMPEG_PARAMETERS_KEY, "")
         self.ffmpeg_post_parameters = CONFIG_OPTIONS.get(self.FFMPEG_POST_PARAMETERS_KEY, "")
 
-        ## Admin commands
+        ## Commands
+        self.add_command(app_commands.Command(
+            name="skip",
+            description=self.skip_command.__doc__,
+            callback=self.skip_command
+        ))
+
+        ## Admin Commands
         @self.admin_cog.admin.command()
         async def skip(ctx):
             """Skips the current audio"""
@@ -419,7 +426,6 @@ class AudioPlayer(Cog):
 
     ## Commands
 
-    @app_commands.command(name="skip")
     async def skip_command(self, interaction: Interaction):
         '''Vote to skip what's currently playing'''
 

--- a/code/common/module/module.py
+++ b/code/common/module/module.py
@@ -1,6 +1,9 @@
 from typing import Callable
 
+from discord import app_commands
 from discord.ext import commands
+from discord.ext.commands import Bot
+
 
 class Module():
     '''
@@ -10,7 +13,7 @@ class Module():
 
     def __init__(self, *args, **kwargs):
         if (self is Module or self is Cog):
-            raise TypeError('{} should be treated as abstract, and shouldn\'t be directly instantiated.'.format(self.__class__.__name__))
+            raise TypeError(f"{self.__class__.__name__} should be treated as abstract, and shouldn't be directly instantiated.")
 
         self._successful = None
         self._after_successful_init = kwargs.get('after_successful_init')
@@ -46,11 +49,42 @@ class Module():
     def after_failed_init(self) -> Callable[[], None]:
         return self._after_failed_init
 
-    
+
     @after_failed_init.setter
     def after_failed_init(self, value: Callable[[], None]):
         self._after_failed_init = value
 
 
 class Cog(Module, commands.Cog):
-    pass
+    def __init__(self, bot: Bot, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.bot = bot
+        self._commands: list[app_commands.Command] = []
+
+    ## Properties
+
+    @property
+    def commands(self) -> list[app_commands.Command]:
+        return self._commands
+
+
+    @commands.setter
+    def commands(self, value: list[app_commands.Command]):
+        self._commands = value
+
+    ## Lifecycle
+
+    async def cog_unload(self):
+        """Cog destructor used to remove commands from cogs at end-of-life"""
+
+        for command in self.commands:
+            self.bot.tree.remove_command(command.name)
+
+    ## Methods
+
+    def add_command(self, command: app_commands.Command):
+        """Adds the command to the cog, and registers the command for future removal"""
+
+        self.commands.append(command)
+        self.bot.tree.add_command(command)

--- a/code/common/privacy_manager.py
+++ b/code/common/privacy_manager.py
@@ -18,7 +18,7 @@ from common.ui.component_factory import ComponentFactory
 
 import discord
 from discord import app_commands, Interaction
-from discord.ext.commands import command, Context
+from discord.ext.commands import command, Context, Bot
 
 ## Config & logging
 CONFIG_OPTIONS = Configuration.load_config()
@@ -27,8 +27,8 @@ LOGGER = Logging.initialize_logging(logging.getLogger(__name__))
 
 class PrivacyManager(Cog):
 
-    def __init__(self, bot, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, bot: Bot, *args, **kwargs):
+        super().__init__(bot, *args, **kwargs)
 
         self.bot = bot
 
@@ -88,7 +88,7 @@ class PrivacyManager(Cog):
 
         # Don't add a privacy policy link if there isn't a URL to link to
         if (self.privacy_policy_url):
-            self.bot.tree.add_command(app_commands.Command(
+            self.add_command(app_commands.Command(
                 name="privacy_policy",
                 description=self.privacy_policy_command.__doc__,
                 callback=self.privacy_policy_command

--- a/code/core/commands/admin.py
+++ b/code/core/commands/admin.py
@@ -9,7 +9,7 @@ from common.module.module import Cog
 from common.module.module_initialization_container import ModuleInitializationContainer
 
 from discord.ext import commands
-from discord.ext.commands import Context, errors
+from discord.ext.commands import Bot, Context, errors
 
 ## Config & logging
 CONFIG_OPTIONS = Configuration.load_config()
@@ -21,8 +21,8 @@ class Admin(Cog):
     ADMINS_KEY = "admins"
     ANNOUNCE_UPDATES_KEY = "announce_updates"
 
-    def __init__(self, hawking: Hawking, bot, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, hawking: Hawking, bot: Bot, *args, **kwargs):
+        super().__init__(bot, *args, **kwargs)
 
         self.hawking = hawking
         self.bot = bot
@@ -87,11 +87,11 @@ class Admin(Cog):
 
         await self.database_manager.store(ctx)
 
-        count = self.hawking.module_manager.reload_registered_modules()
+        count = await self.hawking.module_manager.reload_registered_modules()
         total = len(self.hawking.module_manager.modules)
 
-        loaded_modules_string = "Loaded {} of {} modules/cogs.".format(count, total)
-        await ctx.send(loaded_modules_string)
+        loaded_modules_string = f"Loaded {count} of {total} modules/cogs. Consider syncing commands if anything has changed."
+        await ctx.reply(loaded_modules_string)
 
         return (count >= 0)
 

--- a/code/core/commands/help_cog.py
+++ b/code/core/commands/help_cog.py
@@ -32,7 +32,7 @@ class HelpCog(Cog):
     ## terrible, and no doubt needlessly difficult to maintain in the future, it works.
 
     def __init__(self, bot: commands.Bot, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(bot, *args, **kwargs)
 
         self.bot = bot
 
@@ -76,7 +76,7 @@ class HelpCog(Cog):
             callback=help_command_wrapper,
             extras={"cog": self}
         )
-        self.bot.tree.add_command(self.help_command)
+        self.add_command(self.help_command)
         self.cog_command_tree[HelpCog.__name__] = {self.help_command.name: self.help_command}
         self.command_tree[0][self.help_command.name] = self.help_command
 

--- a/code/core/commands/speech_config_help_command.py
+++ b/code/core/commands/speech_config_help_command.py
@@ -1,4 +1,5 @@
 import logging
+from subprocess import call
 
 from common.configuration import Configuration
 from common.database.database_manager import DatabaseManager
@@ -6,7 +7,9 @@ from common.logging import Logging
 from common.module.module import Cog
 from common.ui.component_factory import ComponentFactory
 
-import discord
+from discord import Interaction
+from discord.app_commands import Command
+from discord.ext.commands import Bot
 
 ## Config & logging
 CONFIG_OPTIONS = Configuration.load_config()
@@ -17,8 +20,8 @@ class SpeechConfigHelpCommand(Cog):
 
     HAWKING_SPEECH_CONFIG_URL = "https://github.com/naschorr/hawking/blob/master/docs/configuring_speech.md"
 
-    def __init__(self, bot, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, bot: Bot, *args, **kwargs):
+        super().__init__(bot, *args, **kwargs)
 
         self.bot = bot
 
@@ -27,10 +30,15 @@ class SpeechConfigHelpCommand(Cog):
         self.database_manager: DatabaseManager = kwargs.get('dependencies', {}).get('DatabaseManager')
         assert (self.database_manager is not None)
 
+        self.add_command(Command(
+            name="speech_config",
+            description=self.speech_config_command.__doc__,
+            callback=self.speech_config_command
+        ))
+
     ## Methods
 
-    @discord.app_commands.command(name="speech_config")
-    async def speech_config_command(self, interaction: discord.Interaction):
+    async def speech_config_command(self, interaction: Interaction):
         """Posts a link to the speech config docs"""
 
         await self.database_manager.store(interaction)

--- a/code/core/speech.py
+++ b/code/core/speech.py
@@ -23,6 +23,7 @@ from common.module.module import Cog
 import async_timeout
 from discord import app_commands, Interaction, Member
 from discord.app_commands import describe
+from discord.ext.commands import Bot
 
 ## Config & logging
 CONFIG_OPTIONS = Configuration.load_config()
@@ -214,8 +215,8 @@ class TTSController:
 
 class Speech(Cog):
 
-    def __init__(self, bot, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, bot: Bot, *args, **kwargs):
+        super().__init__(bot, *args, **kwargs)
 
         self.bot = bot
         self.audio_player_cog: AudioPlayer = kwargs.get('dependencies', {}).get('AudioPlayer')
@@ -228,6 +229,13 @@ class Speech(Cog):
         self.channel_timeout_phrases = CONFIG_OPTIONS.get('channel_timeout_phrases', [])
         self.audio_player_cog.channel_timeout_handler = self.play_random_channel_timeout_message
         self.tts_controller = TTSController()
+
+        ## Commands
+        self.add_command(app_commands.Command(
+            name="say",
+            description=self.say_command.__doc__,
+            callback=self.say_command
+        ))
 
     ## Methods
 
@@ -313,7 +321,6 @@ class Speech(Cog):
 
     ## Commands
 
-    @app_commands.command(name="say")
     @describe(text="The text that Hawking will speak")
     @describe(user="The user that will be spoken to")
     async def say_command(self, interaction: Interaction, text: str, user: Member = None):

--- a/code/hawking.py
+++ b/code/hawking.py
@@ -8,6 +8,7 @@ if (_root_path not in sys.path):
 
 ## Importing as usual now
 import logging
+import asyncio
 
 import discord
 from discord.ext import commands
@@ -126,7 +127,7 @@ class Hawking:
         self.module_manager.discover_modules()
 
         ## Load all of the previously registered modules!
-        self.module_manager.load_registered_modules()
+        asyncio.run(self.module_manager.load_registered_modules())
 
         ## Disable the default help command
         self.bot.help_command = None

--- a/modules/phrases/phrases.py
+++ b/modules/phrases/phrases.py
@@ -22,7 +22,7 @@ from modules.phrases.models.phrase import Phrase
 import discord
 from discord import Interaction
 from discord.app_commands import autocomplete, Choice, describe
-from discord.ext.commands import Context
+from discord.ext.commands import Context, Bot
 
 ## Config & logging
 CONFIG_OPTIONS = Configuration.load_config(Path(__file__).parent)
@@ -35,8 +35,8 @@ class Phrases(DiscoverableCog):
     RANDOM_COMMAND_NAME = "random"
     FIND_COMMAND_NAME = "find"
 
-    def __init__(self, hawking, bot, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, bot: Bot, *args, **kwargs):
+        super().__init__(bot, *args, **kwargs)
 
         self.bot = bot
 
@@ -110,14 +110,14 @@ class Phrases(DiscoverableCog):
         ## Don't register phrase commands if no phrases have been loaded!
         if (self.phrases):
             ## Add the random command
-            self.bot.tree.add_command(discord.app_commands.Command(
+            self.add_command(discord.app_commands.Command(
                 name=Phrases.RANDOM_COMMAND_NAME,
                 description=self.random_command.__doc__,
                 callback=self.random_command
             ))
 
             # Add the find command
-            self.bot.tree.add_command(discord.app_commands.Command(
+            self.add_command(discord.app_commands.Command(
                 name=Phrases.FIND_COMMAND_NAME,
                 description=self.find_command.__doc__,
                 callback=self.find_command
@@ -133,7 +133,7 @@ class Phrases(DiscoverableCog):
             async def phrase_command_wrapper(interaction: Interaction, name: str, user: discord.Member = None):
                 await self.phrase_command(interaction, name, user)
 
-            self.bot.tree.add_command(discord.app_commands.Command(
+            self.add_command(discord.app_commands.Command(
                 name=Phrases.PHRASE_COMMAND_NAME,
                 description=self.phrase_command.__doc__,
                 callback=phrase_command_wrapper,

--- a/modules/stupid_questions/stupid_questions.py
+++ b/modules/stupid_questions/stupid_questions.py
@@ -15,6 +15,7 @@ from question import Question
 
 import discord
 from discord import app_commands, Interaction
+from discord.ext.commands import Bot
 
 ## Config & logging
 CONFIG_OPTIONS = Configuration.load_config(Path(__file__).parent)
@@ -34,10 +35,9 @@ class StupidQuestions(DiscoverableCog):
         "it's now time for us to plant some daffodils of opinion on the roundabout of chat at the end of conversation street, and discuss:"
     ]
 
-    def __init__(self, hawking, bot, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, bot: Bot, *args, **kwargs):
+        super().__init__(bot, *args, **kwargs)
 
-        self.hawking = hawking
         self.bot = bot
 
         self.speech_cog = kwargs.get('dependencies', {}).get('Speech')
@@ -71,9 +71,14 @@ class StupidQuestions(DiscoverableCog):
         except Exception as e:
             raise ModuleLoadException("Unable to create reddit/subreddit instance", e)
 
+        ## Load the questions for polling, async
         asyncio.run(self.load_questions())
 
-        self.successful = True
+        self.add_command(app_commands.Command(
+            name="stupid_question",
+            description=self.stupid_question_command.__doc__,
+            callback=self.stupid_question_command
+        ))
 
 
     async def load_questions(self) -> None:
@@ -110,8 +115,8 @@ class StupidQuestions(DiscoverableCog):
 
         return None
 
+    ## Commands
 
-    @app_commands.command(name="stupid_question")
     async def stupid_question_command(self, interaction: Interaction):
         """Ask a stupid question, via Reddit."""
 


### PR DESCRIPTION
- Upgraded the (Hawking, not discord.py) Cog base class to handle lifecycle operations
- Upgraded Cog base class to register/track commands
- Upgraded Cog base class to remove it's commands when destroyed
- Upgraded Cog children to properly instantiate themselves
- Removed the `hawking` arg sent to cogs (it wasn't being used, and it was a bad idea)
- Migrated a lot of the module management to be async
- Added more type hints all over hawking
- Upgraded the `ModuleManager` to use f-strings instead of format strings